### PR TITLE
Use constant-time comparison for credentials

### DIFF
--- a/basic_auth.go
+++ b/basic_auth.go
@@ -1,6 +1,7 @@
 package httpauth
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
@@ -63,12 +64,12 @@ func (b *basicAuth) authenticate(r *http.Request) bool {
 	// Split on the first ":" character only, with any subsequent colons assumed to be part
 	// of the password. Note that the RFC2617 standard does not place any limitations on
 	// allowable characters in the password.
-	creds := strings.SplitN(string(str), ":", 2)
+	creds := bytes.SplitN(str, []byte(":"), 2)
 
 	// Equalize lengths of supplied and required credentials
 	// by hashing them
-	givenUser := sha256.Sum256([]byte(creds[0]))
-	givenPass := sha256.Sum256([]byte(creds[1]))
+	givenUser := sha256.Sum256(creds[0])
+	givenPass := sha256.Sum256(creds[1])
 	requiredUser := sha256.Sum256([]byte(b.opts.User))
 	requiredPass := sha256.Sum256([]byte(b.opts.Password))
 


### PR DESCRIPTION
Taking cue from martini's [auth](https://github.com/martini-contrib/auth), use constant-time comparison to prevent timing attacks.
