### PR TITLE
Remove extra double quotes from Realm

### DIFF
--- a/basic_auth.go
+++ b/basic_auth.go
@@ -88,7 +88,7 @@ func (b *basicAuth) authenticate(r *http.Request) bool {
 
 // Require authentication, and serve our error handler otherwise.
 func (b *basicAuth) requestAuth(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%q"`, b.opts.Realm))
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm=%q`, b.opts.Realm))
 	b.opts.UnauthorizedHandler.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
According to Go documents `%q` already wraps string with double quotes.

```
%s  the uninterpreted bytes of the string or slice
%q  a double-quoted string safely escaped with Go syntax
%x  base 16, lower-case, two characters per byte
%X  base 16, upper-case, two characters per byte
```

This produces a header like this and breaks Perl LWP::UserAgent->credentials 

```
HTTP/1.1 401 Unauthorized
Content-Type: text/plain; charset=utf-8
Www-Authenticate: Basic realm=""Restricted""
Date: ...
Content-Length: 13
```

Thus, I removed extra quotes and Realm value is now correctly escaped and wrapped into quotes only once[1](http://en.wikipedia.org/wiki/Basic_access_authentication#Server_side)]

```
Www-Authenticate: Basic realm="Restricted"
```
