### PR TITLE
Proper handling of a malformed/bad header data.

### DIFF
--- a/basic_auth.go
+++ b/basic_auth.go
@@ -66,16 +66,16 @@ func (b *basicAuth) authenticate(r *http.Request) bool {
 	// allowable characters in the password.
 	creds := bytes.SplitN(str, []byte(":"), 2)
 
+	if len(creds) != 2 {
+		return false
+	}
+
 	// Equalize lengths of supplied and required credentials
 	// by hashing them
 	givenUser := sha256.Sum256(creds[0])
 	givenPass := sha256.Sum256(creds[1])
 	requiredUser := sha256.Sum256([]byte(b.opts.User))
 	requiredPass := sha256.Sum256([]byte(b.opts.Password))
-
-	if len(creds) != 2 {
-		return false
-	}
 
 	// Compare the supplied credentials to those set in our options
 	if subtle.ConstantTimeCompare(givenUser[:], requiredUser[:]) == 1 &&


### PR DESCRIPTION
In case if you pass a malformed header without the ":" as a delimiter for the username/password you can get unexpected behaviour/error.

Example:

Code:

func main() {
    http.Handle("/", httpauth.SimpleBasicAuth("dejan", "golja")(http.HandlerFunc(handler)))
    http.ListenAndServe(":7000", nil)
}

request:
curl -H 'Authorization: Basic ZGVqYW5nb2xqYQ==' -v -i localhost:7000

Error:
2015/01/06 23:53:22 http: panic serving [::1]:51625: runtime error: index out of range
goroutine 13 [running]:
net/http.func·011()
	/usr/local/go/src/net/http/server.go:1130 +0xbb
github.com/goji/httpauth.(*basicAuth).authenticate(0xc2080463c0, 0xc208032340, 0x31b918)
	/Users/dejan/go/test/src/github.com/goji/httpauth/basic_auth.go:72 +0x54f
github.com/goji/httpauth.basicAuth.ServeHTTP(0x496d28, 0x31b928, 0x2b0890, 0xa, 0x2a4470, 0x5, 0x2a57b0, 0x5, 0x0, 0x0, ...)
	/Users/dejan/go/test/src/github.com/goji/httpauth/basic_auth.go:37 +0xb0
github.com/goji/httpauth.(*basicAuth).ServeHTTP(0xc2080462d0, 0x497ff8, 0xc208056280, 0xc208032340)
	<autogenerated>:1 +0xc4
net/http.(*ServeMux).ServeHTTP(0xc20803a6c0, 0x497ff8, 0xc208056280, 0xc208032340)
	/usr/local/go/src/net/http/server.go:1541 +0x17d
net/http.serverHandler.ServeHTTP(0xc208054060, 0x497ff8, 0xc208056280, 0xc208032340)
	/usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2080561e0)
	/usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:1751 +0x35e


