### PR TITLE
Add support for a AuthFuncWithRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ func main() {
 
 // myAuthFunc is not secure.  It checks to see if the password is simply
 // the username repeated three times.
-func myAuthFunc(user, pass string) bool {
+func myAuthFunc(user, pass string, r *http.Request) bool {
     return pass == strings.Repeat(user, 3)
 }
 ```

--- a/basic_auth.go
+++ b/basic_auth.go
@@ -23,7 +23,7 @@ type AuthOptions struct {
 	Realm               string
 	User                string
 	Password            string
-	AuthFunc            func(string, string) bool
+	AuthFunc            func(string, string, *http.Request) bool
 	UnauthorizedHandler http.Handler
 }
 
@@ -89,12 +89,12 @@ func (b *basicAuth) authenticate(r *http.Request) bool {
 		b.opts.AuthFunc = b.simpleBasicAuthFunc
 	}
 
-	return b.opts.AuthFunc(givenUser, givenPass)
+	return b.opts.AuthFunc(givenUser, givenPass, r)
 }
 
 // simpleBasicAuthFunc authenticates the supplied username and password against
 // the User and Password set in the Options struct.
-func (b *basicAuth) simpleBasicAuthFunc(user, pass string) bool {
+func (b *basicAuth) simpleBasicAuthFunc(user, pass string, r *http.Request) bool {
 	// Equalize lengths of supplied and required credentials
 	// by hashing them
 	givenUser := sha256.Sum256([]byte(user))

--- a/basic_auth_test.go
+++ b/basic_auth_test.go
@@ -10,9 +10,11 @@ func TestBasicAuthAuthenticateWithFunc(t *testing.T) {
 	requiredUser := "jqpublic"
 	requiredPass := "secret.sauce"
 
+	r := &http.Request{Method: "GET"}
+
 	// Dumb test function
-	fn := func(u, p string) bool {
-		return u == requiredUser && p == requiredPass
+	fn := func(u, p string, req *http.Request) bool {
+		return u == requiredUser && p == requiredPass && req == r
 	}
 
 	// Provide a minimal test implementation.
@@ -22,8 +24,6 @@ func TestBasicAuthAuthenticateWithFunc(t *testing.T) {
 	}
 
 	b := &basicAuth{opts: authOpts}
-
-	r := &http.Request{Method: "GET"}
 
 	if b.authenticate(nil) {
 		t.Fatal("Should not succeed when http.Request is nil")


### PR DESCRIPTION
Add support for receiving the `http.Request` object in the authentication function. Good for attaching context to the request, for example using [gorilla/context](https://github.com/gorilla/context).

I first submitted this as https://github.com/goji/httpauth/issues/16, but here's a PR instead.