### PR TITLE
Revert the empty password check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
   allow_failures:
     - go: tip
 
+install:
+  - # skip
+
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)

--- a/basic_auth.go
+++ b/basic_auth.go
@@ -53,9 +53,9 @@ func (b *basicAuth) authenticate(r *http.Request) bool {
 		return false
 	}
 
-	// In simple mode, prevent authentication with empty credentials if User or
-	// Password is not set.
-	if b.opts.AuthFunc == nil && (b.opts.User == "" || b.opts.Password == "") {
+	// In simple mode, prevent authentication with empty credentials if User is
+	// not set. Allow empty passwords to support non-password use-cases.
+	if b.opts.AuthFunc == nil && b.opts.User == "" {
 		return false
 	}
 


### PR DESCRIPTION
As per https://github.com/goji/httpauth/commit/723e9a2b49655f1d067eb9e197b874df3bca973f#commitcomment-17696162 - we should continue to allow empty passwords for API use-cases. Note that Stripe's API, amongst others, support `<api-key>:""` for API authentication.
