### PR TITLE
Compare user and pass hashes simultaneously to avoid leaking if the username is valid

### DIFF
--- a/basic_auth.go
+++ b/basic_auth.go
@@ -102,9 +102,14 @@ func (b *basicAuth) simpleBasicAuthFunc(user, pass string, r *http.Request) bool
 	requiredUser := sha256.Sum256([]byte(b.opts.User))
 	requiredPass := sha256.Sum256([]byte(b.opts.Password))
 
+	// Combine user and pass hashes together into single byte
+	// array to ensure constant time comparison no matter the
+	// combination of user or pass matching.
+	givenUserPass := append(givenUser[:], givenPass[:]...)
+	requiredUserPass := append(requiredUser[:], requiredPass[:]...)
+
 	// Compare the supplied credentials to those set in our options
-	if subtle.ConstantTimeCompare(givenUser[:], requiredUser[:]) == 1 &&
-		subtle.ConstantTimeCompare(givenPass[:], requiredPass[:]) == 1 {
+	if subtle.ConstantTimeCompare(givenUserPass[:], requiredUserPass[:]) == 1 {
 		return true
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/goji/httpauth
+
+go 1.17


### PR DESCRIPTION
Currently the user and pass hashes are compared separately, if the username matches but not the password the middleware will return slightly faster than if both the username and password are wrong.

This change concatenates the user and pass hashes together and compares them in one call to `subtle.ConstantTimeCompare` removing any timing leaks.

I also added a go.mod file.